### PR TITLE
Fix package path in go.mod

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/jheth/hellosign-go-sdk
+module github.com/Preciselyco/hellosign-go-sdk
 
 go 1.14
 


### PR DESCRIPTION
Merging from upstream had introduced a go.mod file, I forgot to change the path inside it.